### PR TITLE
feat: add Hebrew not-found page

### DIFF
--- a/project-agent-mvp/app/not-found.tsx
+++ b/project-agent-mvp/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <html dir="rtl">
+      <body className="flex h-screen items-center justify-center">
+        <div className="text-center">
+          <h2 className="mb-4 text-2xl font-semibold">העמוד לא נמצא</h2>
+          <p className="mb-6">הדף שחיפשת לא קיים. לחזרה ללוח הבקרה לחץ על הקישור הבא.</p>
+          <Link href="/" className="text-blue-600 hover:underline">חזרה לדשבורד</Link>
+        </div>
+      </body>
+    </html>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a right-to-left Hebrew `not-found` page linking users back to the dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to install required TypeScript dependencies: @types/react)*
- `npm run build` *(fails: Module not found for path aliases)*

------
https://chatgpt.com/codex/tasks/task_e_689fbf08e85c8332889011fbac9156aa